### PR TITLE
Fix: plain brackets matching

### DIFF
--- a/src/matchbrackets.ts
+++ b/src/matchbrackets.ts
@@ -150,7 +150,7 @@ function matchPlainBrackets(state: EditorState, pos: number, dir: number, tree: 
       if ((found % 2 == 0) == (dir > 0)) {
         depth++
       } else if (depth == 1) { // Closing
-        return {start: startToken, end: {from: basePos + pos, to: basePos + pos + 1}, matched: (found >> 1) == (bracket >> 1)}
+        return {start: startToken, other: {from: basePos + pos, to: basePos + pos + 1}, matched: (found >> 1) == (bracket >> 1)}
       } else {
         depth--
       }


### PR DESCRIPTION
Hey guys!

Due to `matchPlainBrackets` still returns result like
```
{
 start: ..., 
 end: ..., 
 matched:...
}
```
and when expected `MathResult` should have `other` (instead of `end`), matching plain brackets does not work.

Guess [here](https://github.com/codemirror/codemirror.next/commit/4077512080cdbf69f5e2edd3040803bc3a0d5309#diff-2298caf5048c110a26c592ac56c258c90f28f6f4a84230d665fe97fed469eeb7) `end` was dropped from everywhere in favor of `other`, except in `matchPlainBrackets`.